### PR TITLE
Create termux styling

### DIFF
--- a/git clone https:/github.com/git clone https:/github.com/adi1090x/termux styling
+++ b/git clone https:/github.com/git clone https:/github.com/adi1090x/termux styling
@@ -1,0 +1,53 @@
+# go to home dir - 
+cd $HOME
+
+# clone this repository - 
+git clone https://github.com/adi1090x/termux-style
+
+# change to termux-style dir -
+cd termux-style
+
+# to install it, run -
+./install
+
+# And Follow the steps, it'll be installed on your system.
+Run
+Run termux-style & select the right option -
+
+$ termux-style
+
+    ┌──────────────────────────────────────────────────┐
+    │░▀█▀░█▀▀░█▀▄░█▄█░█░█░█░█░░░░░█▀▀░▀█▀░█░█░█░░░█▀▀░░│
+    │░░█░░█▀▀░█▀▄░█░█░█░█░▄▀▄░▄▄▄░▀▀█░░█░░░█░░█░░░█▀▀░░│
+    │░░▀░░▀▀▀░▀░▀░▀░▀░▀▀▀░▀░▀░░░░░▀▀▀░░▀░░░▀░░▀▀▀░▀▀▀░░│
+    └──────────────────────────────────────────────────┘
+    [*] By- Aditya Shakya // adi1090x
+
+    [C] Colors (89)
+    [F] Fonts (20)
+    [R] Random
+    [I] Import
+    [A] About
+    [Q] Quit
+    
+    [Select Option]: 
+Features
+90 popular color-schemes.
+20 powerline patched fonts.
+Randomly change color-schemes.
+Import color-schemes from local file or file URL.
+Set colors and fonts in place.
+Use Import
+    [Select Option]: 4
+
+    [1] Local File (Enter path to file)
+    [2] Internet File (Enter File URL)
+
+    [Select Option]: 2
+
+    [Enter Color-scheme URL]: https://raw.githubusercontent.com/adi1090x/termux-style/master/colors/gruvbox-dark.properties
+
+    [*] Reloading Settings...
+    [*] Applied Successfully.
+To import local file, enter the full path (e.g. - /data/data/com.termux/files/home/spiderman.properties) of the color-scheme.
+To import web file, enter the file url (e.g. - https://raw.githubusercontent.com/adi1090x/termux-style/master/colors/gruvbox-dark.properties) of the color-scheme.


### PR DESCRIPTION
# And Follow the steps, it'll be installed on your system.
Run
Run termux-style & select the right option -

$ termux-style

    ┌──────────────────────────────────────────────────┐
    │░▀█▀░█▀▀░█▀▄░█▄█░█░█░█░█░░░░░█▀▀░▀█▀░█░█░█░░░█▀▀░░│
    │░░█░░█▀▀░█▀▄░█░█░█░█░▄▀▄░▄▄▄░▀▀█░░█░░░█░░█░░░█▀▀░░│
    │░░▀░░▀▀▀░▀░▀░▀░▀░▀▀▀░▀░▀░░░░░▀▀▀░░▀░░░▀░░▀▀▀░▀▀▀░░│
    └──────────────────────────────────────────────────┘
    [*] By- Aditya Shakya // adi1090x

    [C] Colors (89)
    [F] Fonts (20)
    [R] Random
    [I] Import
    [A] About
    [Q] Quit
    
    [Select Option]: 
Features
90 popular color-schemes.
20 powerline patched fonts.
Randomly change color-schemes.
Import color-schemes from local file or file URL.
Set colors and fonts in place.
Use Import
    [Select Option]: 4

    [1] Local File (Enter path to file)
    [2] Internet File (Enter File URL)

    [Select Option]: 2

    [Enter Color-scheme URL]: https://raw.githubusercontent.com/adi1090x/termux-style/master/colors/gruvbox-dark.properties

    [*] Reloading Settings...
    [*] Applied Successfully.
To import local file, enter the full path (e.g. - /data/data/com.termux/files/home/spiderman.properties) of the color-scheme.
To import web file, enter the file url (e.g. - https://raw.githubusercontent.com/adi1090x/termux-style/master/colors/gruvbox-dark.properties) of the color-scheme.
